### PR TITLE
Fix Telegram types for Next.js build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
     "jsx": "preserve",
     "incremental": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types/**/*.d.ts"],
   "exclude": ["node_modules"]
 }

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,0 +1,14 @@
+interface TelegramWebApp {
+  expand: () => void;
+  sendData: (data: string) => void;
+}
+
+declare global {
+  interface Window {
+    Telegram?: {
+      WebApp: TelegramWebApp;
+    };
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- add global typings for Telegram WebApp
- include those types in tsconfig

## Testing
- `npm run build`
- `npm run lint` *(fails: prompts for ESLint config)*


------
https://chatgpt.com/codex/tasks/task_e_683f478e5014832a95ebf8861dbce24d