### PR TITLE
Fix missing Telegram typings

### DIFF
--- a/types/telegram.d.ts
+++ b/types/telegram.d.ts
@@ -1,0 +1,14 @@
+declare global {
+  interface TelegramWebApp {
+    expand(): void;
+    sendData(data: string): void;
+  }
+
+  interface Window {
+    Telegram?: {
+      WebApp?: TelegramWebApp;
+    };
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- add a global `telegram.d.ts` to describe Telegram WebApp

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683f4206a5e0832a86e24b96ac77dbd8