### PR TITLE
Implement owner chat ID fallback

### DIFF
--- a/pages/api/webhook.ts
+++ b/pages/api/webhook.ts
@@ -20,7 +20,7 @@ export default async function handler(
     if (body.message?.web_app_data?.data) {
       const parsed = JSON.parse(body.message.web_app_data.data);
       const BOT_TOKEN = process.env.BOT_TOKEN;
-      const OWNER_CHAT_ID = process.env.OWNER_CHAT_ID;
+      const OWNER_CHAT_ID = process.env.OWNER_CHAT_ID ?? '7470811680';
       const sendMessageUrl = `https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`;
 
       if (parsed.type === 'order') {


### PR DESCRIPTION
## Summary
- ensure feedback and orders always send to the owner

## Testing
- `npm run lint` *(fails: prompts for interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68400f8a903c832ab312c5ac35e1ca7b