### PR TITLE
Fix Telegram messages to owner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+BOT_TOKEN=your_bot_token_here
+OWNER_CHAT_ID=123456789

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Conditioner Miniapp
+
+This project is a sample Telegram WebApp built with Next.js. It allows customers to place orders and send feedback.
+
+## Environment variables
+
+Create a `.env.local` file and provide the following variables:
+
+```
+BOT_TOKEN=your_bot_token_here
+OWNER_CHAT_ID=your_personal_telegram_id
+```
+
+`BOT_TOKEN` is the token of your Telegram bot. `OWNER_CHAT_ID` should be set to the Telegram ID where order and feedback notifications must be sent. Without these values the webhook will not be able to send messages.
+
+Run the development server with:
+
+```
+npm install
+npm run dev
+```
+
+Make sure the Telegram bot webhook points to `<your-host>/api/webhook`.

--- a/pages/api/webhook.ts
+++ b/pages/api/webhook.ts
@@ -1,6 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import fetch from 'node-fetch';
 
+const escapeMarkdown = (text: string) =>
+  text.replace(/[\\_\*\[\]()~`>#+\-=|{}.!]/g, '\\$&');
+
 type ResponseData = {
   ok: boolean;
   error?: string;
@@ -53,8 +56,8 @@ export default async function handler(
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             chat_id: OWNER_CHAT_ID,
-            parse_mode: 'Markdown',
-            text: `📦 *Новый заказ*\n\nКлиент: ${customerName} (ID: ${fromUser.id})\nСостав заказа:\n${itemsList}\n\nИтого: ${total} ₽`,
+            parse_mode: 'MarkdownV2',
+            text: `📦 *Новый заказ*\n\nКлиент: ${escapeMarkdown(customerName)} (ID: ${fromUser.id})\nСостав заказа:\n${escapeMarkdown(itemsList)}\n\nИтого: ${total} ₽`,
           }),
         });
 
@@ -88,14 +91,14 @@ export default async function handler(
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             chat_id: OWNER_CHAT_ID,
-            parse_mode: 'Markdown',
+            parse_mode: 'MarkdownV2',
             text:
               `📝 *Новая заявка обратной связи*\n\n` +
-              `Имя: ${name}\n` +
-              `Телефон: ${phone}\n` +
-              `Адрес: ${address}\n` +
-              `Услуги: ${serviceListText}\n` +
-              `Комментарий: ${comment || '— без комментариев —'}`,
+              `Имя: ${escapeMarkdown(name)}\n` +
+              `Телефон: ${escapeMarkdown(phone)}\n` +
+              `Адрес: ${escapeMarkdown(address)}\n` +
+              `Услуги: ${escapeMarkdown(serviceListText)}\n` +
+              `Комментарий: ${escapeMarkdown(comment || '— без комментариев —')}`,
           }),
         });
 


### PR DESCRIPTION
## Summary
- escape Markdown characters when building owner notifications
- switch to MarkdownV2 in Telegram API calls
- document required environment variables
- provide env example file

## Testing
- `npm install`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68402abc16c8832a9889711c30f4409b