### PR TITLE
Fix admin order message

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ Create a `.env.local` file and provide the following variables:
 
 ```
 BOT_TOKEN=your_bot_token_here
+# Either OWNER_CHAT_ID or ADMIN_USER_ID will be used
 OWNER_CHAT_ID=your_personal_telegram_id
+ADMIN_USER_ID=
 ```
 
 `*.local` files are ignored by git, so your token won't be committed by mistake.
 
-`BOT_TOKEN` is the token of your Telegram bot. `OWNER_CHAT_ID` must contain the Telegram ID where order and feedback notifications should be sent. Both variables are required; if any of them is missing the webhook will fail.
+`BOT_TOKEN` is the token of your Telegram bot. `OWNER_CHAT_ID` (or `ADMIN_USER_ID`) must contain the Telegram ID where order and feedback notifications should be sent. The webhook will fail if neither variable is provided.
 
 After editing the environment file, restart the Next.js server so the new variables are picked up.
 

--- a/pages/api/webhook.ts
+++ b/pages/api/webhook.ts
@@ -38,10 +38,11 @@ export default async function handler(
     if (body.message?.web_app_data?.data) {
       const parsed = JSON.parse(body.message.web_app_data.data);
       const BOT_TOKEN = process.env.BOT_TOKEN;
-      const OWNER_CHAT_ID = process.env.OWNER_CHAT_ID;
+      const OWNER_CHAT_ID =
+        process.env.OWNER_CHAT_ID || process.env.ADMIN_USER_ID;
 
       if (!BOT_TOKEN || !OWNER_CHAT_ID) {
-        console.error('BOT_TOKEN or OWNER_CHAT_ID not set');
+        console.error('BOT_TOKEN or chat id env var not set');
         return res
           .status(500)
           .json({ ok: false, error: 'Server misconfiguration' });
@@ -70,10 +71,16 @@ export default async function handler(
           ? `@${fromUser.username}`
           : `${fromUser.first_name || ''} ${fromUser.last_name || ''}`.trim() || fromUser.id;
 
+        const userInfo = `${escapeMarkdown(customerName)} ${escapeMarkdown(`(ID: ${fromUser.id})`)}`;
+
         await sendTgMessage(sendMessageUrl, {
           chat_id: OWNER_CHAT_ID,
           parse_mode: 'MarkdownV2',
-          text: `📦 *Новый заказ*\n\nКлиент: ${escapeMarkdown(customerName)} (ID: ${fromUser.id})\nСостав заказа:\n${escapeMarkdown(itemsList)}\n\nИтого: ${total} ₽`,
+          text:
+            `📦 *Новый заказ*\n\n` +
+            `Клиент: ${userInfo}\n` +
+            `Состав заказа:\n${escapeMarkdown(itemsList)}\n\n` +
+            `Итого: ${total} ₽`,
         });
 
         return res.status(200).json({ ok: true });


### PR DESCRIPTION
## Summary
- ensure parentheses in admin order messages are escaped

## Testing
- `npm install --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68455dd3a590832a906d6d343e7569b4